### PR TITLE
use --force option to avoid conflict

### DIFF
--- a/curriculum/git/level-3/git-hard-reset/README.md
+++ b/curriculum/git/level-3/git-hard-reset/README.md
@@ -21,7 +21,7 @@ git log
 
 git reset --hard ec06ba1869a8ffbd1dcc8910e7ca2fa10009503b
 
-git push origin master
+git push origin --force
 ```
 
 ![Git log](img.png)


### PR DESCRIPTION
To clean up the repository and remove references to other commits, we should perform a force push by adding ```--force``` to push command, otherwise git will reject the push.